### PR TITLE
allow angular 1.2 since not all other packages support 1.3 yet

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "src"
   ],
   "dependencies": {
-    "angular": "^1.3.8",
+    "angular": "^1.2.28",
     "chartist": "^0.7.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "mocha": "^2.2.4"
   },
   "dependencies": {
-    "angular": "^1.3.8",
+    "angular": "^1.2.28",
     "chartist": "^0.7.3"
   }
 }


### PR DESCRIPTION
Since this doesn't seem to require angular 1.3 functionality, it'd be ideal if it supported angular 1.2 as well as 1.3. Some popular angular packages still require 1.2 (notably the [bootstrap angular directives](https://github.com/angular-ui/bootstrap)). 