### PR TITLE
fix(package.json): Don't try to install Bower dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "dist/angular-chartist.js",
   "scripts": {
     "build": "npm install && gulp build",
-    "test": "gulp test",
-    "postinstall": "bower install"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Should resolve #64.

I have to confess that I don't know how to test a package.json script without first publishing it to npm... :/
But since this is a very minor change, I think we're ok?